### PR TITLE
add caching and cut slug size

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -27,9 +27,11 @@ export_env "$ENV_DIR"
 
 ### Install aws cli
 puts_step 'install aws cli'
-curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
-unzip awscli-bundle.zip
-./awscli-bundle/install -b ~/bin/aws
+if [ ! -f "$CACHE_DIR/awscli/awscli-bundle" ]; then
+    curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "$CACHE_DIR/awscli/awscli-bundle.zip"
+    unzip "$CACHE_DIR/awscli/awscli-bundle.zip"
+fi
+./"$CACHE_DIR/awscli/awscli-bundle" -b ~/bin/aws
 export PATH=~/bin:$PATH
 
 ### Vendor files into the build dir (which becomes /app at runtime)

--- a/bin/compile
+++ b/bin/compile
@@ -34,7 +34,7 @@ if [ ! -f "$CACHE_DIR/awscli/awscli-bundle" ]; then
     ls $CACHE_DIR/awscli/awscli-bundle
     ls $CACHE_DIR/awscli/awscli-bundle/awscli-bundle
 fi
-. $CACHE_DIR/awscli/awscli-bundle/awscli-bundle/install -b ~/bin/aws
+./$CACHE_DIR/awscli/awscli-bundle/awscli-bundle/install -b ~/bin/aws
 export PATH=~/bin:$PATH
 
 ### Vendor files into the build dir (which becomes /app at runtime)

--- a/bin/compile
+++ b/bin/compile
@@ -61,6 +61,7 @@ cd "$BUILD_DIR/frontend"
 puts_step 'install node dependencies'
 # move cached node_modules
 if [ -d $CACHE_DIR/node-modules-cache/node_modules ]; then
+    echo '>> found cached node_modules directory'
     mv  $CACHE_DIR/node-modules-cache/node_modules $BUILD_DIR/frontend/node_modules
 fi
 # setup yarn cache
@@ -92,6 +93,7 @@ yarn build
 
 # move cache back
 if [ -d $BUILD_DIR/frontend/node_modules ]; then
+    echo '>> saving node_modules directory'
     mv $BUILD_DIR/frontend/node_modules  $CACHE_DIR/node-modules-cache/node_modules
 fi
 

--- a/bin/compile
+++ b/bin/compile
@@ -31,9 +31,9 @@ if [ ! -f "$CACHE_DIR/awscli/awscli-bundle" ]; then
     mkdir -p "$CACHE_DIR/awscli"
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "$CACHE_DIR/awscli/awscli-bundle.zip"
     unzip "$CACHE_DIR/awscli/awscli-bundle.zip" -d "$CACHE_DIR/awscli/awscli-bundle"
-    ls $CACHE_DIR/awscli
+    ls $CACHE_DIR/awscli/awscli-bundle
 fi
-. "$CACHE_DIR/awscli/awscli-bundle/install" -b ~/bin/aws
+. $CACHE_DIR/awscli/awscli-bundle/install -b ~/bin/aws
 export PATH=~/bin:$PATH
 
 ### Vendor files into the build dir (which becomes /app at runtime)

--- a/bin/compile
+++ b/bin/compile
@@ -97,7 +97,8 @@ yarn build
 # move cache back
 if [ -d $BUILD_DIR/frontend/node_modules ]; then
     echo '>> saving node_modules directory'
-    mv $BUILD_DIR/frontend/node_modules  $CACHE_DIR/node-modules-cache/node_modules
+    mkdir -p $CACHE_DIR/node-modules-cache
+    mv $BUILD_DIR/frontend/node_modules  $CACHE_DIR/node-modules-cache
 fi
 
 ### Configure NGINX

--- a/bin/compile
+++ b/bin/compile
@@ -70,7 +70,7 @@ fi
 mkdir -p $CACHE_DIR/yarn-install-cache
 yarn install --frozen-lockfile --non-interactive --cache-folder $CACHE_DIR/yarn-install-cache
 # install toml for poetry conversion script
-yarn add --no-lockfile toml
+yarn add --cache-folder $CACHE_DIR/yarn-install-cache --no-lockfile toml
 
 ### Convert poetry.lock to requirements.txt
 puts_step 'convert python dependencies'

--- a/bin/compile
+++ b/bin/compile
@@ -31,6 +31,7 @@ if [ ! -f "$CACHE_DIR/awscli/awscli-bundle" ]; then
     mkdir -p "$CACHE_DIR/awscli"
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "$CACHE_DIR/awscli/awscli-bundle.zip"
     unzip "$CACHE_DIR/awscli/awscli-bundle.zip" -d "$CACHE_DIR/awscli/awscli-bundle"
+    ls $CACHE_DIR/awscli
 fi
 . "$CACHE_DIR/awscli/awscli-bundle/install" -b ~/bin/aws
 export PATH=~/bin:$PATH

--- a/bin/compile
+++ b/bin/compile
@@ -32,7 +32,7 @@ if [ ! -f "$CACHE_DIR/awscli/awscli-bundle" ]; then
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "$CACHE_DIR/awscli/awscli-bundle.zip"
     unzip "$CACHE_DIR/awscli/awscli-bundle.zip"
 fi
-./"$CACHE_DIR/awscli/awscli-bundle" -b ~/bin/aws
+. "$CACHE_DIR/awscli/awscli-bundle" -b ~/bin/aws
 export PATH=~/bin:$PATH
 
 ### Vendor files into the build dir (which becomes /app at runtime)

--- a/bin/compile
+++ b/bin/compile
@@ -30,7 +30,7 @@ puts_step 'install aws cli'
 if [ ! -f "$CACHE_DIR/awscli/awscli-bundle" ]; then
     mkdir -p "$CACHE_DIR/awscli"
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "$CACHE_DIR/awscli/awscli-bundle.zip"
-    unzip "$CACHE_DIR/awscli/awscli-bundle.zip"
+    unzip "$CACHE_DIR/awscli/awscli-bundle.zip" -d "$CACHE_DIR/awscli/awscli-bundle"
 fi
 . "$CACHE_DIR/awscli/awscli-bundle/install" -b ~/bin/aws
 export PATH=~/bin:$PATH

--- a/bin/compile
+++ b/bin/compile
@@ -59,7 +59,11 @@ echo 'node version:' $(node --version)
 ### Install node dependencies
 cd "$BUILD_DIR/frontend"
 puts_step 'install node dependencies'
-# cache node_modules
+# move cached node_modules
+if [ -d $CACHE_DIR/node-modules-cache/node_modules ]; then
+    mv  $CACHE_DIR/node-modules-cache/node_modules $BUILD_DIR/frontend/node_modules
+fi
+# setup yarn cache
 mkdir -p $CACHE_DIR/yarn-install-cache
 yarn install --frozen-lockfile --non-interactive --cache-folder $CACHE_DIR/yarn-install-cache
 # install toml for poetry conversion script
@@ -85,6 +89,11 @@ cat "$BUILD_DIR/requirements.txt"
 ### Build webpack bundle
 puts_step 'build webpack bundle'
 yarn build
+
+# move cache back
+if [ -d $BUILD_DIR/frontend/node_modules ]; then
+    mv $BUILD_DIR/frontend/node_modules  $CACHE_DIR/node-modules-cache/node_modules
+fi
 
 ### Configure NGINX
 puts_step 'configure nginx'

--- a/bin/compile
+++ b/bin/compile
@@ -27,14 +27,12 @@ export_env "$ENV_DIR"
 
 ### Install aws cli
 puts_step 'install aws cli'
-if [ ! -f "$CACHE_DIR/awscli/awscli-bundle" ]; then
+if [ ! -d "$CACHE_DIR/awscli/awscli-bundle" ]; then
     mkdir -p "$CACHE_DIR/awscli"
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "$CACHE_DIR/awscli/awscli-bundle.zip"
-    unzip "$CACHE_DIR/awscli/awscli-bundle.zip" -d "$CACHE_DIR/awscli/awscli-bundle"
-    ls $CACHE_DIR/awscli/awscli-bundle
-    ls $CACHE_DIR/awscli/awscli-bundle/awscli-bundle/install
+    unzip "$CACHE_DIR/awscli/awscli-bundle.zip" -d "$CACHE_DIR/awscli"
 fi
-.$CACHE_DIR/awscli/awscli-bundle/awscli-bundle/install -b ~/bin/aws
+$CACHE_DIR/awscli/awscli-bundle/install -b ~/bin/aws
 export PATH=~/bin:$PATH
 
 ### Vendor files into the build dir (which becomes /app at runtime)

--- a/bin/compile
+++ b/bin/compile
@@ -28,6 +28,7 @@ export_env "$ENV_DIR"
 ### Install aws cli
 puts_step 'install aws cli'
 if [ ! -f "$CACHE_DIR/awscli/awscli-bundle" ]; then
+    mkdir -p "$CACHE_DIR/awscli"
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "$CACHE_DIR/awscli/awscli-bundle.zip"
     unzip "$CACHE_DIR/awscli/awscli-bundle.zip"
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -31,7 +31,8 @@ if [ ! -f "$CACHE_DIR/awscli/awscli-bundle" ]; then
     mkdir -p "$CACHE_DIR/awscli"
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "$CACHE_DIR/awscli/awscli-bundle.zip"
     unzip "$CACHE_DIR/awscli/awscli-bundle.zip" -d "$CACHE_DIR/awscli/awscli-bundle"
-    tree $CACHE_DIR/awscli/awscli-bundle
+    ls $CACHE_DIR/awscli/awscli-bundle
+    ls $CACHE_DIR/awscli/awscli-bundle/awscli-bundle/install
 fi
 .$CACHE_DIR/awscli/awscli-bundle/awscli-bundle/install -b ~/bin/aws
 export PATH=~/bin:$PATH

--- a/bin/compile
+++ b/bin/compile
@@ -34,7 +34,7 @@ if [ ! -f "$CACHE_DIR/awscli/awscli-bundle" ]; then
     ls $CACHE_DIR/awscli/awscli-bundle
     ls $CACHE_DIR/awscli/awscli-bundle/awscli-bundle
 fi
-. $CACHE_DIR/awscli/awscli-bundle/install -b ~/bin/aws
+. $CACHE_DIR/awscli/awscli-bundle/awscli-bundle/install -b ~/bin/aws
 export PATH=~/bin:$PATH
 
 ### Vendor files into the build dir (which becomes /app at runtime)

--- a/bin/compile
+++ b/bin/compile
@@ -25,16 +25,17 @@ source "$STDLIB_FILE"
 
 export_env "$ENV_DIR"
 
-### Vendor files into the build dir (which becomes /app at runtime)
-
-cd "$BUILD_DIR"
-
 ### Install aws cli
 puts_step 'install aws cli'
 curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "awscli-bundle.zip"
 unzip awscli-bundle.zip
 ./awscli-bundle/install -b ~/bin/aws
 export PATH=~/bin:$PATH
+
+### Vendor files into the build dir (which becomes /app at runtime)
+
+cd "$BUILD_DIR"
+
 
 ### Install node/yarn
 
@@ -82,6 +83,8 @@ cat "$BUILD_DIR/requirements.txt"
 ### Build webpack bundle
 puts_step 'build webpack bundle'
 yarn build
+# we don't need node_modules after we've built the bundles
+rm -rf $BUILD_DIR/frontend/node_modules
 
 ### Configure NGINX
 puts_step 'configure nginx'

--- a/bin/compile
+++ b/bin/compile
@@ -84,7 +84,7 @@ cat "$BUILD_DIR/requirements.txt"
 
 ### Build webpack bundle
 puts_step 'build webpack bundle'
-yarn toml build
+yarn build
 
 ### Configure NGINX
 puts_step 'configure nginx'

--- a/bin/compile
+++ b/bin/compile
@@ -59,9 +59,12 @@ echo 'node version:' $(node --version)
 ### Install node dependencies
 cd "$BUILD_DIR/frontend"
 puts_step 'install node dependencies'
-yarn install --frozen-lockfile --non-interactive
+# cache node_modules
+mkdir -p $CACHE_DIR/yarn-install-cache
+mkdir -p $CACHE_DIR/yarn-modules-cache
+yarn install --frozen-lockfile --non-interactive --cache-folder $CACHE_DIR/yarn-install-cache --modules-folder $CACHE_DIR/yarn-modules-cache
 # install toml for poetry conversion script
-yarn add toml
+yarn add --modules-folder $CACHE_DIR/yarn-modules-cache toml
 
 ### Convert poetry.lock to requirements.txt
 puts_step 'convert python dependencies'
@@ -82,9 +85,7 @@ cat "$BUILD_DIR/requirements.txt"
 
 ### Build webpack bundle
 puts_step 'build webpack bundle'
-yarn build
-# we don't need node_modules after we've built the bundles
-rm -rf $BUILD_DIR/frontend/node_modules
+yarn --modules-folder $CACHE_DIR/yarn-modules-cache toml build
 
 ### Configure NGINX
 puts_step 'configure nginx'

--- a/bin/compile
+++ b/bin/compile
@@ -31,10 +31,9 @@ if [ ! -f "$CACHE_DIR/awscli/awscli-bundle" ]; then
     mkdir -p "$CACHE_DIR/awscli"
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "$CACHE_DIR/awscli/awscli-bundle.zip"
     unzip "$CACHE_DIR/awscli/awscli-bundle.zip" -d "$CACHE_DIR/awscli/awscli-bundle"
-    ls $CACHE_DIR/awscli/awscli-bundle
-    ls $CACHE_DIR/awscli/awscli-bundle/awscli-bundle
+    tree $CACHE_DIR/awscli/awscli-bundle
 fi
-./$CACHE_DIR/awscli/awscli-bundle/awscli-bundle/install -b ~/bin/aws
+.$CACHE_DIR/awscli/awscli-bundle/awscli-bundle/install -b ~/bin/aws
 export PATH=~/bin:$PATH
 
 ### Vendor files into the build dir (which becomes /app at runtime)

--- a/bin/compile
+++ b/bin/compile
@@ -32,6 +32,7 @@ if [ ! -f "$CACHE_DIR/awscli/awscli-bundle" ]; then
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "$CACHE_DIR/awscli/awscli-bundle.zip"
     unzip "$CACHE_DIR/awscli/awscli-bundle.zip" -d "$CACHE_DIR/awscli/awscli-bundle"
     ls $CACHE_DIR/awscli/awscli-bundle
+    ls $CACHE_DIR/awscli/awscli-bundle/awscli-bundle
 fi
 . $CACHE_DIR/awscli/awscli-bundle/install -b ~/bin/aws
 export PATH=~/bin:$PATH

--- a/bin/compile
+++ b/bin/compile
@@ -61,10 +61,9 @@ cd "$BUILD_DIR/frontend"
 puts_step 'install node dependencies'
 # cache node_modules
 mkdir -p $CACHE_DIR/yarn-install-cache
-mkdir -p $CACHE_DIR/yarn-modules-cache
-yarn install --frozen-lockfile --non-interactive --cache-folder $CACHE_DIR/yarn-install-cache --modules-folder $CACHE_DIR/yarn-modules-cache
+yarn install --frozen-lockfile --non-interactive --cache-folder $CACHE_DIR/yarn-install-cache
 # install toml for poetry conversion script
-yarn add --modules-folder $CACHE_DIR/yarn-modules-cache toml
+yarn add --no-lockfile toml
 
 ### Convert poetry.lock to requirements.txt
 puts_step 'convert python dependencies'
@@ -85,7 +84,7 @@ cat "$BUILD_DIR/requirements.txt"
 
 ### Build webpack bundle
 puts_step 'build webpack bundle'
-yarn --modules-folder $CACHE_DIR/yarn-modules-cache toml build
+yarn toml build
 
 ### Configure NGINX
 puts_step 'configure nginx'

--- a/bin/compile
+++ b/bin/compile
@@ -32,7 +32,7 @@ if [ ! -f "$CACHE_DIR/awscli/awscli-bundle" ]; then
     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "$CACHE_DIR/awscli/awscli-bundle.zip"
     unzip "$CACHE_DIR/awscli/awscli-bundle.zip"
 fi
-. "$CACHE_DIR/awscli/awscli-bundle" -b ~/bin/aws
+. "$CACHE_DIR/awscli/awscli-bundle/install" -b ~/bin/aws
 export PATH=~/bin:$PATH
 
 ### Vendor files into the build dir (which becomes /app at runtime)


### PR DESCRIPTION
We've hit the soft limit of 300MB compressed for slugs

- cache node_modules after building our bundle
- don't download aws cli inside BUILD_DIR