### PR TITLE
WIP: add(statsd): install and add statsd to profile.d/ scripts

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -13,6 +13,8 @@ unset GIT_DIR     # Avoid GIT_DIR leak from previous build steps
 BUILD_DIR=${1:-}
 CACHE_DIR=${2:-}
 ENV_DIR=${3:-}
+# from: https://github.com/AdmitHub/heroku-buildpack-python/blob/49863be611110fbee9bdbc768ea722f496127ac1/bin/compile#L29
+BIN_DIR=$(cd "$(dirname "$0")"; pwd) # absolute path
 BP_DIR=$(cd "$(dirname "$0")"; cd ..; pwd)
 PROFILE_D_PATH="$BUILD_DIR/.profile.d"
 # required by `set_env()`
@@ -20,6 +22,7 @@ PROFILE_D_PATH="$BUILD_DIR/.profile.d"
 PROFILE_PATH="$PROFILE_D_PATH/statsd.sh"
 mkdir -p "$PROFILE_D_PATH"
 touch "$PROFILE_PATH"
+EXPORT_PATH="$BIN_DIR/../export"
 
 ### Load the standard lib
 

--- a/bin/compile
+++ b/bin/compile
@@ -46,7 +46,9 @@ cd "$BUILD_DIR"
 mkdir -p .heroku/node
 mkdir -p .heroku/yarn
 # add to path
-export PATH="$PATH:$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin"
+export PATH="$PATH:$HOME/.heroku/node/bin:$HOME/.heroku/yarn/bin"
+# https://github.com/AdmitHub/heroku-buildpack-python/blob/49863be611110fbee9bdbc768ea722f496127ac1/bin/compile#L316
+set_env PATH "\$HOME/.heroku/node/bin:\$PATH"
 
 puts_step 'install node & yarn'
 

--- a/bin/compile
+++ b/bin/compile
@@ -47,6 +47,9 @@ mkdir -p .heroku/node
 mkdir -p .heroku/yarn
 # add to path
 export PATH="$PATH:$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin"
+export PATH="$PATH:/app/.heroku/node/bin"
+# https://github.com/AdmitHub/heroku-buildpack-python/blob/49863be611110fbee9bdbc768ea722f496127ac1/bin/compile#L316
+set_env PATH "\$HOME/.heroku/node/bin:\$PATH"
 
 puts_step 'install node & yarn'
 

--- a/bin/compile
+++ b/bin/compile
@@ -14,6 +14,9 @@ BUILD_DIR=${1:-}
 CACHE_DIR=${2:-}
 ENV_DIR=${3:-}
 BP_DIR=$(cd "$(dirname "$0")"; cd ..; pwd)
+# required by `set_env()`
+# see: https://github.com/heroku/buildpack-stdlib/blob/2611c7d236cfc367eecee9488cf0459d0276955c/stdlib.sh#L69
+PROFILE_PATH="$BUILD_DIR/.profile.d/"
 
 ### Load the standard lib
 
@@ -123,9 +126,8 @@ yarn add statsd-librato-backend@2.0.16
 popd
 # see heroku docs for more info buildpacks with .profile.d/ scripts
 # https://devcenter.heroku.com/articles/buildpack-api#profile-d-scripts
-PROFILE_D_DIR="$BUILD_DIR/.profile.d/"
-mkdir -p "$PROFILE_D_DIR"
-mv "$BUILD_DIR/backend/start-statsd.sh" "$PROFILE_D_DIR"
+mkdir -p "$PROFILE_PATH"
+mv "$BUILD_DIR/backend/start-statsd.sh" "$PROFILE_PATH"
 
 ### Upload frontend static files to S3
 puts_step 'upload static files to s3'

--- a/bin/compile
+++ b/bin/compile
@@ -14,7 +14,7 @@ BUILD_DIR=${1:-}
 CACHE_DIR=${2:-}
 ENV_DIR=${3:-}
 BP_DIR=$(cd "$(dirname "$0")"; cd ..; pwd)
-PROFILE_D_PATH="$BUILD_DIR/.profile.d/"
+PROFILE_D_PATH="$BUILD_DIR/.profile.d"
 # required by `set_env()`
 # see: https://github.com/heroku/buildpack-stdlib/blob/2611c7d236cfc367eecee9488cf0459d0276955c/stdlib.sh#L69
 PROFILE_PATH="$PROFILE_D_PATH/statsd.sh"

--- a/bin/compile
+++ b/bin/compile
@@ -21,7 +21,6 @@ PROFILE_D_PATH="$BUILD_DIR/.profile.d"
 # see: https://github.com/heroku/buildpack-stdlib/blob/2611c7d236cfc367eecee9488cf0459d0276955c/stdlib.sh#L69
 PROFILE_PATH="$PROFILE_D_PATH/statsd.sh"
 mkdir -p "$PROFILE_D_PATH"
-touch "$PROFILE_PATH"
 EXPORT_PATH="$BIN_DIR/../export"
 
 ### Load the standard lib
@@ -57,8 +56,7 @@ mkdir -p .heroku/yarn
 # add to path
 export PATH="$PATH:$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin"
 export PATH="$PATH:/app/.heroku/node/bin"
-# https://github.com/AdmitHub/heroku-buildpack-python/blob/49863be611110fbee9bdbc768ea722f496127ac1/bin/compile#L316
-set_env PATH "\$HOME/.heroku/node/bin:\$PATH"
+
 
 puts_step 'install node & yarn'
 
@@ -133,6 +131,8 @@ popd
 # see heroku docs for more info buildpacks with .profile.d/ scripts
 # https://devcenter.heroku.com/articles/buildpack-api#profile-d-scripts
 mv "$BUILD_DIR/backend/start-statsd.sh" "$PROFILE_PATH"
+# https://github.com/AdmitHub/heroku-buildpack-python/blob/49863be611110fbee9bdbc768ea722f496127ac1/bin/compile#L316
+set_env PATH "\$HOME/.heroku/node/bin:\$PATH"
 
 ### Upload frontend static files to S3
 puts_step 'upload static files to s3'

--- a/bin/compile
+++ b/bin/compile
@@ -18,6 +18,8 @@ PROFILE_D_PATH="$BUILD_DIR/.profile.d"
 # required by `set_env()`
 # see: https://github.com/heroku/buildpack-stdlib/blob/2611c7d236cfc367eecee9488cf0459d0276955c/stdlib.sh#L69
 PROFILE_PATH="$PROFILE_D_PATH/statsd.sh"
+mkdir -p "$PROFILE_D_PATH"
+touch "$PROFILE_PATH"
 
 ### Load the standard lib
 
@@ -127,7 +129,6 @@ yarn add statsd-librato-backend@2.0.16
 popd
 # see heroku docs for more info buildpacks with .profile.d/ scripts
 # https://devcenter.heroku.com/articles/buildpack-api#profile-d-scripts
-mkdir -p "$PROFILE_D_PATH"
 mv "$BUILD_DIR/backend/start-statsd.sh" "$PROFILE_PATH"
 
 ### Upload frontend static files to S3

--- a/bin/compile
+++ b/bin/compile
@@ -46,9 +46,7 @@ cd "$BUILD_DIR"
 mkdir -p .heroku/node
 mkdir -p .heroku/yarn
 # add to path
-export PATH="$PATH:$HOME/.heroku/node/bin:$HOME/.heroku/yarn/bin"
-# https://github.com/AdmitHub/heroku-buildpack-python/blob/49863be611110fbee9bdbc768ea722f496127ac1/bin/compile#L316
-set_env PATH "\$HOME/.heroku/node/bin:\$PATH"
+export PATH="$PATH:$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin"
 
 puts_step 'install node & yarn'
 

--- a/bin/compile
+++ b/bin/compile
@@ -26,14 +26,14 @@ source "$STDLIB_FILE"
 export_env "$ENV_DIR"
 
 ### Install aws cli
-puts_step 'install aws cli'
-if [ ! -d "$CACHE_DIR/awscli/awscli-bundle" ]; then
-    mkdir -p "$CACHE_DIR/awscli"
-    curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "$CACHE_DIR/awscli/awscli-bundle.zip"
-    unzip "$CACHE_DIR/awscli/awscli-bundle.zip" -d "$CACHE_DIR/awscli"
-fi
-$CACHE_DIR/awscli/awscli-bundle/install -b ~/bin/aws
-export PATH=~/bin:$PATH
+# puts_step 'install aws cli'
+# if [ ! -d "$CACHE_DIR/awscli/awscli-bundle" ]; then
+#     mkdir -p "$CACHE_DIR/awscli"
+#     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "$CACHE_DIR/awscli/awscli-bundle.zip"
+#     unzip "$CACHE_DIR/awscli/awscli-bundle.zip" -d "$CACHE_DIR/awscli"
+# fi
+# "$CACHE_DIR/awscli/awscli-bundle/install" -b ~/bin/aws
+export PATH="~/bin:$PATH"
 
 ### Vendor files into the build dir (which becomes /app at runtime)
 
@@ -127,8 +127,8 @@ mkdir -p "$PROFILE_D_DIR"
 mv "$BUILD_DIR/backend/start-statsd.sh" "$PROFILE_D_DIR"
 
 ### Upload frontend static files to S3
-puts_step 'upload static files to s3'
-aws s3 cp --recursive $BUILD_DIR/frontend/build/static "s3://$S3_PUBLIC_ASSET_BUCKET_NAME/frontend/static"
+# puts_step 'upload static files to s3'
+# aws s3 cp --recursive "$BUILD_DIR/frontend/build/static" "s3://$S3_PUBLIC_ASSET_BUCKET_NAME/frontend/static"
 
 ### Compile stuff
 

--- a/bin/compile
+++ b/bin/compile
@@ -14,9 +14,10 @@ BUILD_DIR=${1:-}
 CACHE_DIR=${2:-}
 ENV_DIR=${3:-}
 BP_DIR=$(cd "$(dirname "$0")"; cd ..; pwd)
+PROFILE_D_PATH="$BUILD_DIR/.profile.d/"
 # required by `set_env()`
 # see: https://github.com/heroku/buildpack-stdlib/blob/2611c7d236cfc367eecee9488cf0459d0276955c/stdlib.sh#L69
-PROFILE_PATH="$BUILD_DIR/.profile.d/"
+PROFILE_PATH="$PROFILE_D_PATH/statsd.sh"
 
 ### Load the standard lib
 
@@ -126,7 +127,7 @@ yarn add statsd-librato-backend@2.0.16
 popd
 # see heroku docs for more info buildpacks with .profile.d/ scripts
 # https://devcenter.heroku.com/articles/buildpack-api#profile-d-scripts
-mkdir -p "$PROFILE_PATH"
+mkdir -p "$PROFILE_D_PATH"
 mv "$BUILD_DIR/backend/start-statsd.sh" "$PROFILE_PATH"
 
 ### Upload frontend static files to S3

--- a/bin/compile
+++ b/bin/compile
@@ -108,8 +108,8 @@ cp "$BUILD_DIR/nginx/nginx.conf.erb" "$BUILD_DIR/config"
 
 ### Install StatsD
 puts_step 'setup statsd'
-STATSD_VERSION="v0.8.3"
-STATSD_FILE_NAME="$STATSD_VERSION.zip"
+STATSD_VERSION="0.8.3"
+STATSD_FILE_NAME="v$STATSD_VERSION.zip"
 wget "https://github.com/statsd/statsd/archive/$STATSD_FILE_NAME"
 unzip "$STATSD_FILE_NAME"
 STATSD_DEST_DIR="$BUILD_DIR/backend/statsd"

--- a/bin/compile
+++ b/bin/compile
@@ -49,7 +49,7 @@ mkdir -p .heroku/yarn
 export PATH="$PATH:$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin"
 export PATH="$PATH:/app/.heroku/node/bin"
 # https://github.com/AdmitHub/heroku-buildpack-python/blob/49863be611110fbee9bdbc768ea722f496127ac1/bin/compile#L316
-set_env PATH "/app/.heroku/node/bin:\$PATH"
+# set_env PATH "/app/.heroku/node/bin:\$PATH"
 
 puts_step 'install node & yarn'
 

--- a/bin/compile
+++ b/bin/compile
@@ -49,7 +49,7 @@ mkdir -p .heroku/yarn
 export PATH="$PATH:$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin"
 export PATH="$PATH:/app/.heroku/node/bin"
 # https://github.com/AdmitHub/heroku-buildpack-python/blob/49863be611110fbee9bdbc768ea722f496127ac1/bin/compile#L316
-set_env PATH "\$HOME/.heroku/node/bin:\$PATH"
+set_env PATH "/app/.heroku/node/bin:\$PATH"
 
 puts_step 'install node & yarn'
 

--- a/bin/compile
+++ b/bin/compile
@@ -128,12 +128,12 @@ mv "statsd-$STATSD_VERSION" "$STATSD_DEST_DIR"
 pushd "$STATSD_DEST_DIR"
 yarn add statsd-librato-backend@2.0.16
 popd
+# https://github.com/AdmitHub/heroku-buildpack-python/blob/49863be611110fbee9bdbc768ea722f496127ac1/bin/compile#L316
+# we want this to be at the start of what will be statsd.sh
+set_env PATH "\$HOME/.heroku/node/bin:\$PATH"
 # see heroku docs for more info buildpacks with .profile.d/ scripts
 # https://devcenter.heroku.com/articles/buildpack-api#profile-d-scripts
-mv "$BUILD_DIR/backend/start-statsd.sh" "$PROFILE_PATH"
-# https://github.com/AdmitHub/heroku-buildpack-python/blob/49863be611110fbee9bdbc768ea722f496127ac1/bin/compile#L316
-set_env PATH "\$HOME/.heroku/node/bin:\$PATH"
-
+cat "$BUILD_DIR/backend/start-statsd.sh" >> "$PROFILE_PATH"
 ### Upload frontend static files to S3
 puts_step 'upload static files to s3'
 aws s3 cp --recursive $BUILD_DIR/frontend/build/static "s3://$S3_PUBLIC_ASSET_BUCKET_NAME/frontend/static"

--- a/bin/compile
+++ b/bin/compile
@@ -26,14 +26,14 @@ source "$STDLIB_FILE"
 export_env "$ENV_DIR"
 
 ### Install aws cli
-# puts_step 'install aws cli'
-# if [ ! -d "$CACHE_DIR/awscli/awscli-bundle" ]; then
-#     mkdir -p "$CACHE_DIR/awscli"
-#     curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "$CACHE_DIR/awscli/awscli-bundle.zip"
-#     unzip "$CACHE_DIR/awscli/awscli-bundle.zip" -d "$CACHE_DIR/awscli"
-# fi
-# "$CACHE_DIR/awscli/awscli-bundle/install" -b ~/bin/aws
-export PATH="~/bin:$PATH"
+puts_step 'install aws cli'
+if [ ! -d "$CACHE_DIR/awscli/awscli-bundle" ]; then
+    mkdir -p "$CACHE_DIR/awscli"
+    curl "https://s3.amazonaws.com/aws-cli/awscli-bundle.zip" -o "$CACHE_DIR/awscli/awscli-bundle.zip"
+    unzip "$CACHE_DIR/awscli/awscli-bundle.zip" -d "$CACHE_DIR/awscli"
+fi
+$CACHE_DIR/awscli/awscli-bundle/install -b ~/bin/aws
+export PATH=~/bin:$PATH
 
 ### Vendor files into the build dir (which becomes /app at runtime)
 
@@ -127,8 +127,8 @@ mkdir -p "$PROFILE_D_DIR"
 mv "$BUILD_DIR/backend/start-statsd.sh" "$PROFILE_D_DIR"
 
 ### Upload frontend static files to S3
-# puts_step 'upload static files to s3'
-# aws s3 cp --recursive "$BUILD_DIR/frontend/build/static" "s3://$S3_PUBLIC_ASSET_BUCKET_NAME/frontend/static"
+puts_step 'upload static files to s3'
+aws s3 cp --recursive $BUILD_DIR/frontend/build/static "s3://$S3_PUBLIC_ASSET_BUCKET_NAME/frontend/static"
 
 ### Compile stuff
 

--- a/bin/compile
+++ b/bin/compile
@@ -58,7 +58,7 @@ mkdir -p .heroku/yarn
 export PATH="$PATH:$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin"
 export PATH="$PATH:/app/.heroku/node/bin"
 # https://github.com/AdmitHub/heroku-buildpack-python/blob/49863be611110fbee9bdbc768ea722f496127ac1/bin/compile#L316
-set_env PATH "$PATH"
+set_env PATH "\$HOME/.heroku/node/bin:\$PATH"
 
 puts_step 'install node & yarn'
 

--- a/bin/compile
+++ b/bin/compile
@@ -49,7 +49,7 @@ mkdir -p .heroku/yarn
 export PATH="$PATH:$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin"
 export PATH="$PATH:/app/.heroku/node/bin"
 # https://github.com/AdmitHub/heroku-buildpack-python/blob/49863be611110fbee9bdbc768ea722f496127ac1/bin/compile#L316
-# set_env PATH "/app/.heroku/node/bin:\$PATH"
+set_env PATH "$PATH"
 
 puts_step 'install node & yarn'
 

--- a/bin/compile
+++ b/bin/compile
@@ -106,6 +106,24 @@ puts_step 'configure nginx'
 mkdir -p "$BUILD_DIR/config"
 cp "$BUILD_DIR/nginx/nginx.conf.erb" "$BUILD_DIR/config"
 
+### Install StatsD
+puts_step 'setup statsd'
+STATSD_VERSION="v0.8.3"
+STATSD_FILE_NAME="$STATSD_VERSION.zip"
+wget "https://github.com/statsd/statsd/archive/$STATSD_FILE_NAME"
+unzip "$STATSD_FILE_NAME"
+STATSD_DEST_DIR="$BUILD_DIR/backend/statsd"
+mv "statsd-$STATSD_VERSION" "$STATSD_DEST_DIR"
+# install librato backend
+pushd "$STATSD_DEST_DIR"
+yarn add statsd-librato-backend@2.0.16
+popd
+# see heroku docs for more info buildpacks with .profile.d/ scripts
+# https://devcenter.heroku.com/articles/buildpack-api#profile-d-scripts
+PROFILE_D_DIR="$BUILD_DIR/.profile.d/"
+mkdir -p "$PROFILE_D_DIR"
+mv "$BUILD_DIR/backend/start-statsd.sh" "$PROFILE_D_DIR"
+
 ### Upload frontend static files to S3
 puts_step 'upload static files to s3'
 aws s3 cp --recursive $BUILD_DIR/frontend/build/static "s3://$S3_PUBLIC_ASSET_BUCKET_NAME/frontend/static"


### PR DESCRIPTION
Add statsd to buildpack. Statsd is run via profile.d/ scripts.

For more info on how Heroku handles these scripts see the relevant docs:
https://devcenter.heroku.com/articles/buildpack-api#profile-d-scripts