### PR TITLE
ref: frontend build setup to copy files from s3 bucket – AH-2648

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -67,7 +67,7 @@ readonly frontend_asset_file="frontend.tar.gz"
 readonly git_sha="${SOURCE_VERSION}"
 aws s3 cp "s3://${S3_AH_BUILD_ARTIFACTS_BUCKET_NAME}/${git_sha}/${frontend_asset_file}" "${frontend_asset_file}"
 readonly static_files_dir="$(mktemp -d)"
-tar xf "${frontend_assert_file}" -C "${static_files_dir}"
+tar xf "${frontend_asset_file}" -C "${static_files_dir}"
 aws s3 cp --recursive "${static_files_dir}/build/static" "s3://${S3_PUBLIC_ASSET_BUCKET_NAME}/frontend/static"
 
 ### Compile stuff

--- a/bin/compile
+++ b/bin/compile
@@ -39,13 +39,39 @@ export PATH=~/bin:$PATH
 
 cd "$BUILD_DIR"
 
-### Install node
-puts_step 'install node'
+
+### Install node/yarn
+
+# create directory for installed utilities
 mkdir -p .heroku/node
-export PATH="$PATH:$BUILD_DIR/.heroku/node/bin"
+mkdir -p .heroku/yarn
+# add to path
+export PATH="$PATH:$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin"
+
+puts_step 'install node & yarn'
+
 curl --silent --retry 5 --retry-max-time 15 "https://nodejs.org/dist/v11.11.0/node-v11.11.0-linux-x64.tar.xz" -o /tmp/node.tar.xz
 tar xf /tmp/node.tar.xz -C .heroku/node --strip 1
+
+curl --silent --retry 5 --retry-max-time 15 -L "https://github.com/yarnpkg/yarn/releases/download/v1.15.0/yarn-v1.15.0.tar.gz" -o /tmp/yarn.tar.gz
+tar zxf /tmp/yarn.tar.gz -C .heroku/yarn --strip 1
+
+echo 'yarn version:' $(yarn --version)
 echo 'node version:' $(node --version)
+
+### Install node dependencies
+cd "$BUILD_DIR/frontend"
+puts_step 'install node dependencies'
+# move cached node_modules
+if [ -d $CACHE_DIR/node-modules-cache/node_modules ]; then
+    echo '>> found cached node_modules directory'
+    mv  $CACHE_DIR/node-modules-cache/node_modules $BUILD_DIR/frontend/node_modules
+fi
+# setup yarn cache
+mkdir -p $CACHE_DIR/yarn-install-cache
+yarn install --frozen-lockfile --non-interactive --cache-folder $CACHE_DIR/yarn-install-cache
+# install toml for poetry conversion script
+yarn add --cache-folder $CACHE_DIR/yarn-install-cache --no-lockfile toml
 
 ### Convert poetry.lock to requirements.txt
 puts_step 'convert python dependencies'
@@ -63,6 +89,14 @@ fi
 node 'toml-to-requirements.js' "$LOCKFILE" > "$BUILD_DIR/requirements.txt"
 puts_step 'converted python requirements'
 cat "$BUILD_DIR/requirements.txt"
+
+
+# move cache back
+if [ -d $BUILD_DIR/frontend/node_modules ]; then
+    echo '>> saving node_modules directory'
+    mkdir -p $CACHE_DIR/node-modules-cache
+    mv $BUILD_DIR/frontend/node_modules  $CACHE_DIR/node-modules-cache
+fi
 
 ### Configure NGINX
 puts_step 'configure nginx'

--- a/bin/compile
+++ b/bin/compile
@@ -118,7 +118,7 @@ fi
 readonly frontend_asset_file="frontend.tar.gz"
 readonly git_sha="${SOURCE_VERSION}"
 puts_step 'copying files from s3'
-aws s3 cp "s3://${S3_AH_BUILD_ARTIFACTS_BUCKET_NAME}/${git_sha}/${frontend_asset_file}" "${frontend_asset_file}"
+aws s3 cp "s3://${S3_AH_BUILD_ARTIFACTS_BUCKET_NAME}/marshall/${git_sha}/frontend/${frontend_asset_file}" "${frontend_asset_file}"
 readonly static_files_dir="$(mktemp -d)"
 puts_step 'unarchiving frontend files'
 tar xf "${frontend_asset_file}" -C "${static_files_dir}"

--- a/bin/compile
+++ b/bin/compile
@@ -69,15 +69,8 @@ echo 'node version:' $(node --version)
 ### Install node dependencies
 cd "$BUILD_DIR/frontend"
 puts_step 'install node dependencies'
-# move cached node_modules
-if [ -d $CACHE_DIR/node-modules-cache/node_modules ]; then
-    echo '>> found cached node_modules directory'
-    mv  $CACHE_DIR/node-modules-cache/node_modules $BUILD_DIR/frontend/node_modules
-fi
-# setup yarn cache
-mkdir -p $CACHE_DIR/yarn-install-cache
 # install toml for poetry conversion script
-yarn add --cache-folder $CACHE_DIR/yarn-install-cache --no-lockfile toml
+yarn add --no-lockfile toml
 
 ### Convert poetry.lock to requirements.txt
 puts_step 'convert python dependencies'
@@ -94,14 +87,6 @@ fi
 node 'toml-to-requirements.js' "$LOCKFILE" > "$BUILD_DIR/requirements.txt"
 puts_step 'converted python requirements'
 cat "$BUILD_DIR/requirements.txt"
-
-
-# move cache back
-if [ -d $BUILD_DIR/frontend/node_modules ]; then
-    echo '>> saving node_modules directory'
-    mkdir -p $CACHE_DIR/node-modules-cache
-    mv $BUILD_DIR/frontend/node_modules  $CACHE_DIR/node-modules-cache
-fi
 
 ### Configure NGINX
 puts_step 'configure nginx'

--- a/bin/compile
+++ b/bin/compile
@@ -76,7 +76,6 @@ if [ -d $CACHE_DIR/node-modules-cache/node_modules ]; then
 fi
 # setup yarn cache
 mkdir -p $CACHE_DIR/yarn-install-cache
-yarn install --frozen-lockfile --non-interactive --cache-folder $CACHE_DIR/yarn-install-cache
 # install toml for poetry conversion script
 yarn add --cache-folder $CACHE_DIR/yarn-install-cache --no-lockfile toml
 

--- a/bin/compile
+++ b/bin/compile
@@ -39,40 +39,6 @@ export PATH=~/bin:$PATH
 
 cd "$BUILD_DIR"
 
-
-### Install node/yarn
-
-# create directory for installed utilities
-mkdir -p .heroku/node
-mkdir -p .heroku/yarn
-# add to path
-export PATH="$PATH:$BUILD_DIR/.heroku/node/bin:$BUILD_DIR/.heroku/yarn/bin"
-
-puts_step 'install node & yarn'
-
-curl --silent --retry 5 --retry-max-time 15 "https://nodejs.org/dist/v11.11.0/node-v11.11.0-linux-x64.tar.xz" -o /tmp/node.tar.xz
-tar xf /tmp/node.tar.xz -C .heroku/node --strip 1
-
-curl --silent --retry 5 --retry-max-time 15 -L "https://github.com/yarnpkg/yarn/releases/download/v1.15.0/yarn-v1.15.0.tar.gz" -o /tmp/yarn.tar.gz
-tar zxf /tmp/yarn.tar.gz -C .heroku/yarn --strip 1
-
-echo 'yarn version:' $(yarn --version)
-echo 'node version:' $(node --version)
-
-### Install node dependencies
-cd "$BUILD_DIR/frontend"
-puts_step 'install node dependencies'
-# move cached node_modules
-if [ -d $CACHE_DIR/node-modules-cache/node_modules ]; then
-    echo '>> found cached node_modules directory'
-    mv  $CACHE_DIR/node-modules-cache/node_modules $BUILD_DIR/frontend/node_modules
-fi
-# setup yarn cache
-mkdir -p $CACHE_DIR/yarn-install-cache
-yarn install --frozen-lockfile --non-interactive --cache-folder $CACHE_DIR/yarn-install-cache
-# install toml for poetry conversion script
-yarn add --cache-folder $CACHE_DIR/yarn-install-cache --no-lockfile toml
-
 ### Convert poetry.lock to requirements.txt
 puts_step 'convert python dependencies'
 cp "$BP_DIR/toml-to-requirements.js" .
@@ -90,17 +56,6 @@ node 'toml-to-requirements.js' "$LOCKFILE" > "$BUILD_DIR/requirements.txt"
 puts_step 'converted python requirements'
 cat "$BUILD_DIR/requirements.txt"
 
-### Build webpack bundle
-puts_step 'build webpack bundle'
-yarn build
-
-# move cache back
-if [ -d $BUILD_DIR/frontend/node_modules ]; then
-    echo '>> saving node_modules directory'
-    mkdir -p $CACHE_DIR/node-modules-cache
-    mv $BUILD_DIR/frontend/node_modules  $CACHE_DIR/node-modules-cache
-fi
-
 ### Configure NGINX
 puts_step 'configure nginx'
 mkdir -p "$BUILD_DIR/config"
@@ -108,7 +63,12 @@ cp "$BUILD_DIR/nginx/nginx.conf.erb" "$BUILD_DIR/config"
 
 ### Upload frontend static files to S3
 puts_step 'upload static files to s3'
-aws s3 cp --recursive $BUILD_DIR/frontend/build/static "s3://$S3_PUBLIC_ASSET_BUCKET_NAME/frontend/static"
+readonly frontend_asset_file="frontend.tar.gz"
+readonly git_sha="${SOURCE_VERSION}"
+aws s3 cp "s3://${S3_AH_BUILD_ARTIFACTS_BUCKET_NAME}/${git_sha}/${frontend_asset_file}" "${frontend_asset_file}"
+readonly static_files_dir="$(mktemp -d)"
+tar xf "${frontend_assert_file}" -C "${static_files_dir}"
+aws s3 cp --recursive "${static_files_dir}/build/static" "s3://${S3_PUBLIC_ASSET_BUCKET_NAME}/frontend/static"
 
 ### Compile stuff
 

--- a/bin/compile
+++ b/bin/compile
@@ -39,6 +39,14 @@ export PATH=~/bin:$PATH
 
 cd "$BUILD_DIR"
 
+### Install node
+puts_step 'install node'
+mkdir -p .heroku/node
+export PATH="$PATH:$BUILD_DIR/.heroku/node/bin"
+curl --silent --retry 5 --retry-max-time 15 "https://nodejs.org/dist/v11.11.0/node-v11.11.0-linux-x64.tar.xz" -o /tmp/node.tar.xz
+tar xf /tmp/node.tar.xz -C .heroku/node --strip 1
+echo 'node version:' $(node --version)
+
 ### Convert poetry.lock to requirements.txt
 puts_step 'convert python dependencies'
 cp "$BP_DIR/toml-to-requirements.js" .

--- a/bin/compile
+++ b/bin/compile
@@ -119,7 +119,11 @@ readonly frontend_asset_file="frontend.tar.gz"
 readonly git_sha="${SOURCE_VERSION}"
 puts_step 'copying files from s3'
 aws s3 cp "s3://${S3_AH_BUILD_ARTIFACTS_BUCKET_NAME}/marshall/${git_sha}/frontend/${frontend_asset_file}" "${frontend_asset_file}"
-readonly static_files_dir="$(mktemp -d)"
+# We purposely leave the assets on the host for NGINX.
+# NGINX looks on the host machine first and then checks S3 if a file isn't there.
+# This handles people on older bundles. However, we don't store the
+# `index.html` file in S3 as it determines which version the app is running.
+readonly static_files_dir="$BUILD_DIR/frontend/"
 puts_step 'unarchiving frontend files'
 tar xf "${frontend_asset_file}" -C "${static_files_dir}"
 puts_step 'uploading files to s3'

--- a/bin/compile
+++ b/bin/compile
@@ -21,6 +21,13 @@ STDLIB_FILE=$(mktemp -t stdlib.XXXXX)
 curl --silent --retry 5 --retry-max-time 15 'https://lang-common.s3.amazonaws.com/buildpack-stdlib/v7/stdlib.sh' > "$STDLIB_FILE"
 source "$STDLIB_FILE"
 
+### Helper functions
+
+fail() {
+    echo "${1}" 1>&2
+    exit 1
+}
+
 ### Load env vars
 
 export_env "$ENV_DIR"
@@ -82,8 +89,7 @@ if [ -f $BUILD_DIR/backend/poetry.lock ]; then
 elif [ -f $BUILD_DIR/backend/pyproject.lock ]; then
   LOCKFILE=$BUILD_DIR/backend/pyproject.lock
 else
-  echo "Lockfile not found!" 1>&2
-  exit 1
+  fail "Lockfile not found!"
 fi
 
 node 'toml-to-requirements.js' "$LOCKFILE" > "$BUILD_DIR/requirements.txt"
@@ -105,6 +111,12 @@ cp "$BUILD_DIR/nginx/nginx.conf.erb" "$BUILD_DIR/config"
 
 ### Upload frontend static files to S3
 puts_step 'upload static files to s3'
+if [[ -z "${S3_AH_BUILD_ARTIFACTS_BUCKET_NAME}" ]]; then
+  fail "build artifacts s3 bucket name not set"
+fi
+if [[ -z "${S3_PUBLIC_ASSET_BUCKET_NAME}" ]]; then
+  fail "public assets s3 bucket name not set"
+fi
 readonly frontend_asset_file="frontend.tar.gz"
 readonly git_sha="${SOURCE_VERSION}"
 aws s3 cp "s3://${S3_AH_BUILD_ARTIFACTS_BUCKET_NAME}/${git_sha}/${frontend_asset_file}" "${frontend_asset_file}"

--- a/bin/compile
+++ b/bin/compile
@@ -118,9 +118,12 @@ if [[ -z "${S3_PUBLIC_ASSET_BUCKET_NAME}" ]]; then
 fi
 readonly frontend_asset_file="frontend.tar.gz"
 readonly git_sha="${SOURCE_VERSION}"
+puts_step 'copying files from s3'
 aws s3 cp "s3://${S3_AH_BUILD_ARTIFACTS_BUCKET_NAME}/${git_sha}/${frontend_asset_file}" "${frontend_asset_file}"
 readonly static_files_dir="$(mktemp -d)"
+puts_step 'unarchiving frontend files'
 tar xf "${frontend_asset_file}" -C "${static_files_dir}"
+puts_step 'uploading files to s3'
 aws s3 cp --recursive "${static_files_dir}/build/static" "s3://${S3_PUBLIC_ASSET_BUCKET_NAME}/frontend/static"
 
 ### Compile stuff

--- a/bin/compile
+++ b/bin/compile
@@ -109,7 +109,6 @@ mkdir -p "$BUILD_DIR/config"
 cp "$BUILD_DIR/nginx/nginx.conf.erb" "$BUILD_DIR/config"
 
 ### Upload frontend static files to S3
-puts_step 'upload static files to s3'
 if [[ -z "${S3_AH_BUILD_ARTIFACTS_BUCKET_NAME}" ]]; then
   fail "build artifacts s3 bucket name not set"
 fi

--- a/bin/compile
+++ b/bin/compile
@@ -108,11 +108,11 @@ aws s3 cp "s3://${S3_AH_BUILD_ARTIFACTS_BUCKET_NAME}/marshall/${git_sha}/fronten
 # NGINX looks on the host machine first and then checks S3 if a file isn't there.
 # This handles people on older bundles. However, we don't store the
 # `index.html` file in S3 as it determines which version the app is running.
-readonly static_files_dir="$BUILD_DIR/frontend/"
+readonly frontend_dir="${BUILD_DIR}/frontend/"
 puts_step 'unarchiving frontend files'
-tar xf "${frontend_asset_file}" -C "${static_files_dir}"
+tar xf "${frontend_asset_file}" -C "${frontend_dir}"
 puts_step 'uploading files to s3'
-aws s3 cp --recursive "${static_files_dir}/build/static" "s3://${S3_PUBLIC_ASSET_BUCKET_NAME}/frontend/static"
+aws s3 cp --recursive "${frontend_dir}/build/static" "s3://${S3_PUBLIC_ASSET_BUCKET_NAME}/frontend/static"
 
 ### Compile stuff
 


### PR DESCRIPTION
Previously we were building the frontend web component of the app in
Heroku which took about 8mins. Now we build the frontend in CI and copy
over the static files to the Heroku host and then unpack and copy the files
we want to the public s3 bucket.

This change adds an additional ENV var to the script:

`S3_AH_BUILD_ARTIFACTS_BUCKET_NAME`

which is our private bucket for build artifacts.


[AH-2648]

[AH-2648]: https://admithubteam.atlassian.net/browse/AH-2648