### PR TITLE
fix: yarn add so it doesn't consult package.json – AH-2648

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -14,6 +14,7 @@ BUILD_DIR=${1:-}
 CACHE_DIR=${2:-}
 ENV_DIR=${3:-}
 BP_DIR=$(cd "$(dirname "$0")"; cd ..; pwd)
+readonly start_time="$(date +%s)"
 
 ### Load the standard lib
 
@@ -108,5 +109,6 @@ puts_step 'uploading files to s3'
 aws s3 cp --recursive "${frontend_dir}/build/static" "s3://${S3_PUBLIC_ASSET_BUCKET_NAME}/frontend/static"
 
 ### Compile stuff
+readonly end_time="$(date +%s)"
 
-echo "🎉  Finished!"
+echo "🎉 Finished in $(( end_time - start_time ))s"

--- a/bin/compile
+++ b/bin/compile
@@ -73,9 +73,10 @@ puts_step 'install node dependencies'
 # dependencies.
 poetry_convert_dir="$(mktemp -d)"
 cp "${BUILD_DIR}/backend/poetry.lock" "${poetry_convert_dir}"
+cp "${BP_DIR}/toml-to-requirements.js" "${poetry_convert_dir}"
 pushd "${poetry_convert_dir}"
-yarn add --no-lockfile toml
-node "${BP_DIR}/toml-to-requirements.js" poetry.lock > "${BUILD_DIR}/requirements.txt"
+yarn add toml
+node "toml-to-requirements.js" poetry.lock > "${BUILD_DIR}/requirements.txt"
 popd
 cat "${BUILD_DIR}/requirements.txt"
 puts_step 'converted python requirements finished!'

--- a/bin/compile
+++ b/bin/compile
@@ -66,27 +66,16 @@ tar zxf /tmp/yarn.tar.gz -C .heroku/yarn --strip 1
 echo 'yarn version:' $(yarn --version)
 echo 'node version:' $(node --version)
 
-### Install node dependencies
-cd "$BUILD_DIR/frontend"
+### Convert poetry.lock to requirements.txt for Heroku's Python buildpack
 puts_step 'install node dependencies'
-# install toml for poetry conversion script
+poetry_convert_dir="$(mktemp -d)"
+cp "${BUILD_DIR}/backend/poetry.lock" "${poetry_convert_dir}"
+pushd "${poetry_convert_dir}"
 yarn add --no-lockfile toml
-
-### Convert poetry.lock to requirements.txt
-puts_step 'convert python dependencies'
-cp "$BP_DIR/toml-to-requirements.js" .
-
-if [ -f $BUILD_DIR/backend/poetry.lock ]; then
-  LOCKFILE=$BUILD_DIR/backend/poetry.lock
-elif [ -f $BUILD_DIR/backend/pyproject.lock ]; then
-  LOCKFILE=$BUILD_DIR/backend/pyproject.lock
-else
-  fail "Lockfile not found!"
-fi
-
-node 'toml-to-requirements.js' "$LOCKFILE" > "$BUILD_DIR/requirements.txt"
-puts_step 'converted python requirements'
-cat "$BUILD_DIR/requirements.txt"
+node "${BP_DIR}/toml-to-requirements.js" poetry.lock > "${BUILD_DIR}/requirements.txt"
+popd
+cat "${BUILD_DIR}/requirements.txt"
+puts_step 'converted python requirements finished!'
 
 ### Configure NGINX
 puts_step 'configure nginx'

--- a/bin/compile
+++ b/bin/compile
@@ -68,6 +68,9 @@ echo 'node version:' $(node --version)
 
 ### Convert poetry.lock to requirements.txt for Heroku's Python buildpack
 puts_step 'install node dependencies'
+# Note: we install and convert the deps in a different dir from the project so
+# that `yarn` doesn't try and version solve with the `package.json` and its
+# dependencies.
 poetry_convert_dir="$(mktemp -d)"
 cp "${BUILD_DIR}/backend/poetry.lock" "${poetry_convert_dir}"
 pushd "${poetry_convert_dir}"

--- a/bin/compile
+++ b/bin/compile
@@ -8,6 +8,8 @@ set -o errexit    # always exit on error
 set -o pipefail   # don't ignore exit codes when piping output
 unset GIT_DIR     # Avoid GIT_DIR leak from previous build steps
 
+echo "started @ $(date -u)"
+
 ### Configure directories
 
 BUILD_DIR=${1:-}

--- a/bin/release
+++ b/bin/release
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# https://devcenter.heroku.com/articles/buildpack-api#bin-release
+
+cat << EOF
+addons: []
+default_process_types:
+    web: ls -a && ls webpack_bundle && env && echo $PWD
+EOF

--- a/bin/release
+++ b/bin/release
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-# https://devcenter.heroku.com/articles/buildpack-api#bin-release
-
-cat << EOF
-addons: []
-default_process_types:
-    web: ls -a && ls webpack_bundle && env && echo $PWD
-EOF

--- a/bin/release
+++ b/bin/release
@@ -1,8 +1,4 @@
 #!/usr/bin/env bash
 # https://devcenter.heroku.com/articles/buildpack-api#bin-release
 
-cat << EOF
-addons: []
-default_process_types:
-    web: ls -a && ls webpack_bundle && env && echo $PWD
-EOF
+echo "releasing @ $(date -u)"

--- a/bin/release
+++ b/bin/release
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
 # https://devcenter.heroku.com/articles/buildpack-api#bin-release
 
-echo "releasing @ $(date -u)"
+cat << EOF
+addons: []
+default_process_types:
+    web: ls -a && ls webpack_bundle && env && echo $PWD
+EOF


### PR DESCRIPTION
`yarn add` previously would consult our project's `package.json` which resulted in `yarn` spending around 2 minutes resolving dependencies.

Now we install the `toml` node package and convert the poetry lock file in its own directory.

Additionally we remove the `bin/release` which isn't used and is also outdated

[AH-2648]

[AH-2648]: https://admithubteam.atlassian.net/browse/AH-2648