### PR TITLE
fix: wait for frontend bundle to be available

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -105,7 +105,7 @@ while [ ! "$(aws s3 ls "$asset_path")" ]; do
     sleep 1
 done
 puts_step 'copying files from s3'
-aws s3 cp "s3://${S3_AH_BUILD_ARTIFACTS_BUCKET_NAME}/marshall/${git_sha}/frontend/${frontend_asset_file}" "${frontend_asset_file}"
+aws s3 cp "$asset_path" "${frontend_asset_file}"
 # We purposely leave the assets on the host for NGINX.
 # NGINX looks on the host machine first and then checks S3 if a file isn't there.
 # This handles people on older bundles. However, we don't store the

--- a/bin/compile
+++ b/bin/compile
@@ -100,7 +100,7 @@ readonly frontend_asset_file="frontend.tar.gz"
 readonly git_sha="${SOURCE_VERSION}"
 readonly asset_path="s3://${S3_AH_BUILD_ARTIFACTS_BUCKET_NAME}/marshall/${git_sha}/frontend/${frontend_asset_file}"
 puts_step 'checking for frontend build files in s3'
-while [ ! "$(aws s3 ls $asset_path)" ]; do
+while [ ! "$(aws s3 ls "$asset_path")" ]; do
     puts_step 'frontend build files not found, waiting 1 second'
     sleep 1
 done

--- a/bin/compile
+++ b/bin/compile
@@ -98,6 +98,12 @@ if [[ -z "${S3_PUBLIC_ASSET_BUCKET_NAME}" ]]; then
 fi
 readonly frontend_asset_file="frontend.tar.gz"
 readonly git_sha="${SOURCE_VERSION}"
+readonly asset_path="s3://${S3_AH_BUILD_ARTIFACTS_BUCKET_NAME}/marshall/${git_sha}/frontend/${frontend_asset_file}"
+puts_step 'checking for frontend build files in s3'
+while [ ! "$(aws s3 ls $asset_path)" ]; do
+    puts_step 'frontend build files not found, waiting 1 second'
+    sleep 1
+done
 puts_step 'copying files from s3'
 aws s3 cp "s3://${S3_AH_BUILD_ARTIFACTS_BUCKET_NAME}/marshall/${git_sha}/frontend/${frontend_asset_file}" "${frontend_asset_file}"
 # We purposely leave the assets on the host for NGINX.


### PR DESCRIPTION
review apps don't wait for CI to finish, so when they try to fetch the frontend bundle built in CircleCI, they'll likely get a 404. Now instead we poll until the file exists. Heroku builds have a 15 minute time limit, so I think it's okay that we don't have our own time limit here.

<img width="601" alt="Screen Shot 2020-11-20 at 10 10 17 AM" src="https://user-images.githubusercontent.com/1929960/99815691-a3aa7980-2b18-11eb-81f6-07687c6097ce.png">
